### PR TITLE
Created Add/Delete Admin functionality

### DIFF
--- a/MainApp/lib/app/models/admin.js
+++ b/MainApp/lib/app/models/admin.js
@@ -1,0 +1,19 @@
+import mongoose from 'mongoose';
+const Schema = mongoose.Schema;
+
+const manageAdminSchema = new Schema({
+    emailId: {
+        type: String,
+        lowercase: true,
+        required: true,
+        unique: true
+    },
+    role:{
+        type: String,
+        uppercase: true,
+        required: true,
+        enum: ['ADMIN', 'SUPER ADMIN']
+    }
+});
+
+export default mongoose.model('ManageAdmin', manageAdminSchema, 'admins');

--- a/MainApp/lib/app/routes/api.js
+++ b/MainApp/lib/app/routes/api.js
@@ -1,6 +1,7 @@
 import Admin from '../models/user';
 import TrialInfo from '../models/trialinfo';
 import GameConfig from '../models/gameConfig';
+import ManageAdmin from '../models/admin';
 
 export default function (router) {
     //http://localhost:8080/api/admin
@@ -95,14 +96,54 @@ export default function (router) {
             });
         }
     });
-    
+
     //http://localhost:8080/api/adminLogin
-    router.post("/adminLogin",function(req,res) {
-        Admin.count({ username: req.body.email }, function(err,count) {
-            if(count>0) {
+    router.post("/adminLogin", function (req, res) {
+        Admin.count({username: req.body.email}, function (err, count) {
+            if (count > 0) {
                 res.send(true);
             } else {
                 res.send(false);
+            }
+        });
+    });
+
+    router.post("/newAdmin", function (req, res) {
+        let manageAdmin = new ManageAdmin();
+        manageAdmin.emailId = req.body.emailId;
+        manageAdmin.role = "ADMIN";
+        if (!manageAdmin.emailId) {
+            res.send({success: false, message: 'Email was empty'});
+        } else {
+            manageAdmin.save(function (error) {
+                if (error) {
+                    console.log(error);
+                    res.send({success: false, message: "Email Id already exists"});
+                } else {
+                    res.send({success: true, message: "Admin saved"});
+                }
+            });
+        }
+    });
+
+    router.get("/viewAdmin", function (req, res) {
+        ManageAdmin.find({}, function (error, docs) {
+            if (error) {
+                console.log(error);
+                res.send({success: false, message: "Error"});
+            } else {
+                res.send({success: true, message: "Found users", data: docs});
+            }
+        });
+    });
+
+    router.post("/deleteAdmin", function (req, res) {
+        ManageAdmin.remove({emailId: req.body.emailId}, function(error){
+            if (error) {
+                console.log(error);
+                res.send({success: false, message: "Email Id doesn't exist"});
+            } else {
+                res.send({success: true, message: "Admin deleted"});
             }
         });
     });

--- a/MainApp/public/app/app.js
+++ b/MainApp/public/app/app.js
@@ -2,12 +2,11 @@ angular.module('trialInfoApp', ['appRoutes', 'trialInfoControllers', 'trialInfoS
     //console.log('testing trialInfo app');
 });
 
+angular.module('gameApp', ['appRoutes', 'gamePageControllers', 'ngAnimate']).config(function () {
+    //console.log('testing game app');
+});
 
- angular.module('gameApp', ['appRoutes', 'gamePageControllers', 'ngAnimate']).config(function () {
-     //console.log('testing game app');
- });
-
-angular.module('userApp', ['appRoutes', 'authControllers', 'authServices', 'adminControllers', 'adminServices', 'ngAnimate', 'trialInfoApp', 'gameConfigApp', 'gameApp']).config(function () {
+angular.module('userApp', ['appRoutes', 'authControllers', 'authServices', 'adminControllers', 'adminServices', 'ngAnimate', 'trialInfoApp', 'gameConfigApp', 'gameApp', 'manageAdminApp']).config(function () {
     //console.log('testing user app');
 });
 
@@ -15,4 +14,7 @@ angular.module('gameConfigApp', ['appRoutes', 'gameConfigControllers', 'gameConf
     /*console.log('testing game config app');*/
 });
 
+angular.module('manageAdminApp', ['appRoutes', 'manageAdminControllers', 'manageAdminServices', 'ngAnimate']).config(function () {
+    /*console.log('testing manageAdmin app');*/
+});
 

--- a/MainApp/public/app/controllers/manageAdminCtrl.js
+++ b/MainApp/public/app/controllers/manageAdminCtrl.js
@@ -1,0 +1,42 @@
+angular.module('manageAdminControllers', ['manageAdminServices'])
+    .controller('manageAdminCtrl', function (ManageAdmin, $scope) {
+        $scope.createNewAdmin = function () {
+            $scope.successMsg = false;
+            $scope.errorMsg = false;
+            $scope.loading = true;
+            $scope.email = JSON.stringify({emailId: $scope.emailId});
+            ManageAdmin.create($scope.email).then(function (returnData) {
+                if (returnData.data.success) {
+                    $scope.successMsg = returnData.data.message;
+                    $scope.adminList = false;
+                    $scope.listAdmin();
+                } else {
+                    $scope.errorMsg = returnData.data.message;
+                }
+                $scope.loading = false;
+            });
+        };
+
+        $scope.removeAdmin = function(adminEmail){
+            adminEmail = JSON.stringify({emailId: adminEmail});
+            ManageAdmin.deleteAdm(adminEmail).then(function (returnData){
+                if (returnData.data.success) {
+                    // TODO: Add some indicator of success or failure
+                    //console.log(returnData.data.message);
+                    $scope.adminList = false;
+                    $scope.listAdmin();
+                } else {
+                    //console.log(returnData.data.message);
+                }
+            });
+        };
+
+        $scope.adminList = false;
+        $scope.listAdmin = function(){
+            ManageAdmin.view().then(function (returnData) {
+                if (returnData.data.success) {
+                    $scope.adminList = returnData.data.data;
+                }
+            });
+        };
+    });

--- a/MainApp/public/app/routes.js
+++ b/MainApp/public/app/routes.js
@@ -20,6 +20,9 @@ angular.module('appRoutes', ['ngRoute']).config(function ($routeProvider, $locat
         .when('/gameconfigpage', {
             templateUrl: 'app/views/pages/admin/gameConfigPage.html' , controller: 'gameConfigCtrl', controllerAs: 'gameConf'
         })
+        .when('/manageAdmin', {
+            templateUrl: 'app/views/pages/admin/manageAdmin.html' , controller: 'manageAdminCtrl', controllerAs: 'manageAdm'
+        })
         .otherwise({redirectTo: '/'});
 
     $locationProvider.html5Mode({

--- a/MainApp/public/app/services/manageAdminServices.js
+++ b/MainApp/public/app/services/manageAdminServices.js
@@ -1,0 +1,14 @@
+angular.module('manageAdminServices', [])
+    .factory('ManageAdmin', function ($http) {
+        manageAdminFactory = {};
+        manageAdminFactory.create = function(newAdminData){
+            return $http.post('/api/newAdmin', newAdminData);
+        };
+        manageAdminFactory.view = function(){
+            return $http.get('/api/viewAdmin');
+        };
+        manageAdminFactory.deleteAdm = function(adminEmailData){
+            return $http.post('/api/deleteAdmin', adminEmailData);
+        };
+        return manageAdminFactory;
+    });

--- a/MainApp/public/app/views/index.html
+++ b/MainApp/public/app/views/index.html
@@ -32,6 +32,7 @@
     <script src="app/controllers/gameConfigCtrl.js"></script>
     <script src="app/controllers/gamePageCtrl.js"></script>
     <script src="app/controllers/authCtrl.js"></script>
+    <script src="app/controllers/manageAdminCtrl.js"></script>
 
     
     <!--Angular Services-->
@@ -39,6 +40,7 @@
     <script src="app/services/trialInfoServices.js"></script>
     <script src="app/services/gameConfigServices.js"></script>
     <script src="app/services/authServices.js"></script>
+    <script src="app/services/manageAdminServices.js"></script>
     
 
     <title>Index</title>
@@ -60,7 +62,7 @@
             <ul class="nav navbar-nav">
                 <li class="active"><a href="/">Home</a></li>
                 <li><a href="/about">About</a></li>
-
+                <li><a href="/manageAdmin">Manage Admin</a></li>
                 <li><a href="/gameconfigpage">New Game</a></li>
                 <li class="dropdown">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"

--- a/MainApp/public/app/views/pages/admin/manageAdmin.html
+++ b/MainApp/public/app/views/pages/admin/manageAdmin.html
@@ -1,0 +1,62 @@
+<div class="page-header">
+    <h1>Manage Admin</h1>
+</div>
+<div class="row" ng-controller="manageAdminCtrl">
+    <div class="col-lg-6">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">Add New Admin</h3>
+            </div>
+            <div class="panel-body">
+                <form ng-submit="createNewAdmin();">
+                    <label>Email Id:</label>
+                    <input class="form-control" type="text" name="emailId" placeholder="Enter email"
+                           ng-model="emailId">
+                    <br>
+                    <button class="btn btn-success" type="submit">Add Admin</button>
+                </form>
+
+                <div class="jumbotron text-center" ng-show="loading">
+                    <span class="glyphicon glyphicon-repeat spinner"></span>
+
+                    <p>Loading...</p>
+                </div>
+
+                <div class="row show-hide-message" ng-show="successMsg">
+                    <div class="alert alert-success">
+                        {{successMsg}}
+                    </div>
+                </div>
+                <div class="row show-hide-message" ng-show="errorMsg">
+                    <div class="alert alert-danger">
+                        {{errorMsg}}
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-lg-6">
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">Delete Admin</h3>
+            </div>
+            <div class="panel-body" ng-init="listAdmin()">
+                <table class="table table-striped table-hover ">
+                    <thead>
+                    <tr>
+                        <th>Users</th>
+                        <th></th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr ng-repeat="admin in adminList">
+                        <td>{{admin.emailId}}</td>
+                        <td><input type="button" class="btn btn-danger" value="Delete"
+                                   ng-click="removeAdmin(admin.emailId)"></td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Created a new page where the superadmin can add/view/delete admins
Note: Created a new schema called admins. This schema will replace the
current 'admin' schema or viceversa. It has 2 fields - email and role. The
role can be ADMIN or SUPER ADMIN.
Todos:
- There is a data consistency issue with the admin list generated for a
  second until it is fetched from the database. Add/delete admin to see
  what I mean. Maybe this can be solved through promises and a loading
  spinner.
- Validation for the email field in Add functionality
- This page should be only visible for the super admin user.
- Maybe a modal should pop up to confirm the deletion of a admin.